### PR TITLE
Reduce redo-logs in size

### DIFF
--- a/openproject-template.json
+++ b/openproject-template.json
@@ -251,6 +251,14 @@
                                         "value": "${RAILS_DB_PASSWORD}"
                                     },
                                     {
+                                        "name": "MYSQL_INNODB_LOG_FILE_SIZE",
+                                        "value": "32M"
+                                    },
+                                    {
+                                        "name": "MYSQL_INNODB_LOG_BUFFER_SIZE",
+                                        "value": "32M"
+                                    },
+                                    {
                                         "name": "MYSQL_DATABASE",
                                         "value": "${RAILS_DB_NAME}"
                                     }


### PR DESCRIPTION
This size is probably still too big, but closer to the needed value. The built-in default creates 160MB files, the factory-default is 8M.

As a absolutely wanted side-effect, the free space on the PV should increase.